### PR TITLE
Fix encryption keys in VCR config rails-helper.

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -83,8 +83,8 @@ end
 VCR.configure do |config|
   config.cassette_library_dir = 'spec/fixtures/vcr_cassettes'
   config.hook_into :webmock
-  config.filter_sensitive_data('<encrypted_key>') { ENV['image_api_key'] }
-  config.filter_sensitive_data('<encrypted_key>') { ENV['google_client_id'] }
-  config.filter_sensitive_data('<encrypted_key>') { ENV['client_secret_id'] }
+  config.filter_sensitive_data('<encrypted_image_key>') { ENV['image_api_key'] }
+  config.filter_sensitive_data('<encrypted_google_client_key>') { ENV['google_client_id'] }
+  config.filter_sensitive_data('<encrypted_client_secret_id>') { ENV['client_secret_id'] }
   config.configure_rspec_metadata!
 end


### PR DESCRIPTION
- fix bug in VCR config where each encrypted key was the same. This solves the odd VCR issues we had before.